### PR TITLE
updated numark mixtrack 3 controller script with soft takeover method selection

### DIFF
--- a/res/controllers/Numark-Mixtrack-3-scripts.js
+++ b/res/controllers/Numark-Mixtrack-3-scripts.js
@@ -1067,13 +1067,6 @@ NumarkMixtrack3.deckFromGroup = function(group) { // DFG // for easy find
     return this.decks["D" + decknum];
 };
 
-NumarkMixtrack3.deck.prototype.getKnobStateObject = function (group, control) {
-    for (var i = 0; i <= this.KnobState.length; i++) {
-       if(this.KnobState[i].group == group && this.KnobState[i].control == control)
-        return this.KnobState[i];
-       }
-};
-
 NumarkMixtrack3.ShiftButton = function(channel, control, value, status, group) {
     var deck = NumarkMixtrack3.deckFromGroup(group);
     deck.shiftKey = (value === DOWN);

--- a/res/controllers/Numark-Mixtrack-3-scripts.js
+++ b/res/controllers/Numark-Mixtrack-3-scripts.js
@@ -24,6 +24,9 @@ var ShiftFilterFX4 = true;
 // allow pitch bend with wheel when wheel is not active
 var PitchBendOnWheelOff = true;
 
+// use mixxx softtakeover implementation instead of the script implemented method
+// suggestion: true 
+var UseEngineSoftTakeOver = true;
 /**************************
  *  scriptpause
  * ---------------
@@ -231,6 +234,15 @@ function parameterSoftTakeOver(group, control, value) {
 // Reusable Objects (special buttons handling, LEDs, iCUT and Jog wheels)
 // =====================================================================
 
+// Knob state object to keep shift press to trigger engine's softtakeoverignore properly
+var KnobState = function (group, control, state) {
+    this.group = group;
+    this.control = control;
+    this.state = state;
+
+    if(UseEngineSoftTakeOver)
+        engine.softTakeover(group, control, UseEngineSoftTakeOver); 
+};
 // LED class object
 var LED = function(control, midino) {
     this.control = control;
@@ -729,6 +741,16 @@ NumarkMixtrack3.deck = function(decknum) {
     this.Jog = new Jogger(this.group, this.decknum);
     this.duration = 0;
 
+    // Knob State Objects to store shift presses and trigger softtakeoverignore properly on certain knobs
+    // Knob State Objects automatically sets engine's softtakeover true if @UseEngineSoftTakeOver is true
+    this.KnobState = [];
+    this.KnobState.pregain = new KnobState(this.group, "pregain", false);
+    this.KnobState.EQLow = new KnobState("[EqualizerRack1_" + this.group + "_Effect1]", "parameter1", false);
+    this.KnobState.EQMid = new KnobState("[EqualizerRack1_" + this.group + "_Effect1]", "parameter2", false);
+    this.KnobState.EQHigh = new KnobState("[EqualizerRack1_" + this.group + "_Effect1]", "parameter3", false);
+    this.KnobState.QuickFilter = new KnobState("[QuickEffectRack1_" + this.group + "]", "super1", false);
+
+    //[ChannelI]_Effect1]
     engine.setValue("[EffectRack1_EffectUnit" + decknum + "]", "show_focus", true);
 
     // buttons
@@ -1043,6 +1065,13 @@ NumarkMixtrack3.deckFromGroup = function(group) { // DFG // for easy find
     group = NumarkMixtrack3.deckGroup[group];
     var decknum = parseInt(group.substring(8, 9));
     return this.decks["D" + decknum];
+};
+
+NumarkMixtrack3.deck.prototype.getKnobStateObject = function (group, control) {
+    for (var i = 0; i <= this.KnobState.length; i++) {
+       if(this.KnobState[i].group == group && this.KnobState[i].control == control)
+        return this.KnobState[i];
+       }
 };
 
 NumarkMixtrack3.ShiftButton = function(channel, control, value, status, group) {
@@ -1831,15 +1860,42 @@ NumarkMixtrack3.EQKnob = function(channel, control, value, status, group) {
     var focusedEffect = deck.getFocusedEffect();
     var EQp = 4 - control; // convert control number to parameter number in mixxx
     var FXp = control; // control number matches effect param order
+    
+    switch (EQp) {
+        case 1:
+            var knobStateOBJ = deck.KnobState.EQLow;
+            break;
+        case 2:
+            var knobStateOBJ = deck.KnobState.EQMid;
+            break;
+        case 3:
+            var knobStateOBJ = deck.KnobState.EQHigh;
+            break;
+        }     
 
     // default behavior is to control EQ
     // when shifted, change parameters of focused effect
     if (deck.shiftKey && focusedEffect) {
-        parameterSoftTakeOver(
+        // enable softtakeover since effect parameter changed dynamically 
+        if(UseEngineSoftTakeOver)
+            engine.softTakeover("[EffectRack1_EffectUnit" + decknum + "_Effect" + focusedEffect +"]", "parameter" + FXp, true);
+        deck.handleSoftTakeOver(
             "[EffectRack1_EffectUnit" + decknum + "_Effect" + focusedEffect +"]", "parameter" + FXp, value
         );
+
+        // set takeover ignore if using engine's softtakeover instead of scripted one
+        if (UseEngineSoftTakeOver && knobStateOBJ.state == false) {
+            knobStateOBJ.state = true;
+            engine.softTakeoverIgnoreNextValue(knobStateOBJ.group, knobStateOBJ.control);
+        }
     } else {
-        parameterSoftTakeOver("[EqualizerRack1_[Channel" + decknum + "]_Effect1]", "parameter" + EQp, value);
+        deck.handleSoftTakeOver("[EqualizerRack1_[Channel" + decknum + "]_Effect1]", "parameter" + EQp, value);
+
+       // set takeover ignore if using engine's softtakeover instead of scripted one
+        if (UseEngineSoftTakeOver && knobStateOBJ.state == true) {
+            knobStateOBJ.state = false;
+            engine.softTakeoverIgnoreNextValue("[EffectRack1_EffectUnit" + decknum + "_Effect" + focusedEffect +"]", "parameter" + FXp);
+        }
     }
 };
 
@@ -1854,15 +1910,33 @@ NumarkMixtrack3.FilterKnob = function(channel, control, value, status, group) {
         // Default behavior for Shift+Filter is to change FX4
         // for the currently focused effect
         if (focusedEffect && ShiftFilterFX4) {
-            parameterSoftTakeOver(
-                "[EffectRack1_EffectUnit" + decknum + "_Effect" + focusedEffect + "]", "parameter4", value
-            );
+            deck.handleSoftTakeOver("[EffectRack1_EffectUnit" + decknum + "_Effect" + focusedEffect + "]", "parameter4", value);
         } else {
-            // Shift+Filter is mapped to channel gain otherwise
-            parameterSoftTakeOver("[Channel" + decknum + "]", "pregain", value);
+            // Shift+Filter is mapped to channel gain otherwise               
+            deck.handleSoftTakeOver("[Channel" + decknum + "]", "pregain", value);
+            // set takeover ignore if using engine's softtakeover instead of scripted one
+            if (UseEngineSoftTakeOver && deck.KnobState.pregain.state == false) {
+                deck.KnobState.pregain.state = true;
+                engine.softTakeoverIgnoreNextValue(deck.KnobState.QuickFilter.group, deck.KnobState.QuickFilter.control);
+            }
         }
     } else {
-        parameterSoftTakeOver("[QuickEffectRack1_[Channel" + decknum + "]]", "super1", value);
+        deck.handleSoftTakeOver("[QuickEffectRack1_[Channel" + decknum + "]]", "super1", value);
+        // set takeover ignore if using engine's softtakeover instead of scripted one
+        if (UseEngineSoftTakeOver && deck.KnobState.pregain.state == true) {
+           deck.KnobState.pregain.state = false;
+            engine.softTakeoverIgnoreNextValue(deck.KnobState.pregain.group, deck.KnobState.pregain.control);
+        }
+    }
+};
+
+// handle softovertake method automatically deciding between mixxx engine's default or implemented via this script
+NumarkMixtrack3.deck.prototype.handleSoftTakeOver = function (group, control, value) {
+    if (UseEngineSoftTakeOver) {
+         engine.setParameter(group, control, value / 127);
+         return;
+    } else {
+        parameterSoftTakeOver(group, control, value);
     }
 };
 


### PR DESCRIPTION
implemented a simple configurable way to make possible use of engine's softtakeover method over the custom implementation.
applied to gain / filter / eq knobs by default including shift + knob as well.