### PR TITLE
[Library]: added scriptable TriggerItem library control to extend ori…

### DIFF
--- a/res/controllers/Numark-Mixtrack-3-scripts.js
+++ b/res/controllers/Numark-Mixtrack-3-scripts.js
@@ -27,6 +27,10 @@ var PitchBendOnWheelOff = true;
 // use mixxx softtakeover implementation instead of the script implemented method
 // suggestion: true 
 var UseEngineSoftTakeOver = true;
+
+// true (default) - simple (without shift) Browse Button press toggles library maximization
+// false - simple browse button does nothing
+var BrowseButtonToggleLibrary = true;
 /**************************
  *  scriptpause
  * ---------------
@@ -1102,14 +1106,13 @@ NumarkMixtrack3.BrowseButton = function(channel, control, value, status, group) 
 
     if (value === ON) {
 	    if (shifted) {
+            engine.setValue("[Library]", "TriggerItem", 0);
 	        // SHIFT + BROWSE push : directory mode -- > Open/Close selected side bar item
-	        engine.setValue("[Library]", "GoToItem", true);
 	    } else {
 	        // Browse push : maximize/minimize library view
-	        if (value === ON) {
+            if(BrowseButtonToggleLibrary)
 	            script.toggleControl("[Skin]", "show_maximized_library");
 	        }
-	    }
     }
 };
 

--- a/src/library/librarycontrol.cpp
+++ b/src/library/librarycontrol.cpp
@@ -217,6 +217,26 @@ LibraryControl::LibraryControl(Library* pLibrary)
                 &LibraryControl::slotGoToItem);
     }
 
+    // controllable "gotoitem" trigger with basic context dependent functionality
+    // value = -1: using default/original gotoitem implementation
+    // value = 0: prefer and check if any valid toggleable item is selected on the sidebar widget and toggle selected item
+    // value 1,2,3,4,5: target library focus method, convert value to @FocusWidget enum and set library focus before calling gotoitem
+    // 1 = Searchbar
+    // 2 = Sidebar
+    // 3 = TracksTable
+    // 4 = ContextMenu
+    // 5 = Dialog
+    m_pTriggerItem = std::make_unique<ControlObject>(ConfigKey("[Library]", "TriggerItem"), false);
+    #ifdef MIXXX_USE_QML
+    if (!CmdlineArgs::Instance().isQml())
+#endif
+    {
+        connect(m_pTriggerItem.get(),
+            &ControlObject::valueChanged,
+            this,
+            &LibraryControl::slotTriggerItem);
+    }
+
     // Auto DJ controls
     m_pAutoDjAddTop = std::make_unique<ControlPushButton>(ConfigKey("[Library]","AutoDjAddTop"));
     m_pAutoDjAddTop->addAlias(ConfigKey(
@@ -1011,6 +1031,35 @@ void LibraryControl::slotGoToItem(double v) {
     default:
         setLibraryFocus(FocusWidget::TracksTable);
     }
+}
+
+void LibraryControl::slotTriggerItem(double v) {
+    const int triggerItemMethod = static_cast<int>(v);
+
+    // use default gotoitem implementation
+    if(triggerItemMethod == -1) {
+        slotGoToItem(1);
+        return;
+    }
+
+    // check and try toggle items selected on sidebar first if possible
+    if(triggerItemMethod == 0) {
+        if (!m_pSidebarWidget->isLeafNodeSelected()) {
+            setLibraryFocus(FocusWidget::Sidebar);
+            m_pSidebarWidget->toggleSelectedItem();
+        }else slotGoToItem(1);
+        return;
+    }
+
+    // todo: update if focuswidget enum changes
+    // enum overrun
+    if(triggerItemMethod > 5)
+        return;
+
+    // value stores a possible focus target, try set that focus and call gotoitem
+    const FocusWidget targetFocus = static_cast<FocusWidget>(triggerItemMethod);
+    setLibraryFocus(targetFocus);
+    slotGoToItem(1);
 }
 
 void LibraryControl::slotSortColumn(double v) {

--- a/src/library/librarycontrol.h
+++ b/src/library/librarycontrol.h
@@ -80,6 +80,7 @@ class LibraryControl : public QObject {
     void slotMoveFocusBackward(double);
     void slotMoveFocus(double);
     void slotGoToItem(double v);
+    void slotTriggerItem(double v);
 
     void slotTrackColorPrev(double v);
     void slotTrackColorNext(double v);
@@ -142,6 +143,9 @@ class LibraryControl : public QObject {
 
     // Control to choose the currently selected item in focused widget (double click)
     std::unique_ptr<ControlObject> m_pGoToItem;
+
+    // Control to choose
+    std::unique_ptr<ControlObject> m_pTriggerItem;
 
     // Add to Auto-Dj Queue
     std::unique_ptr<ControlObject> m_pAutoDjAddTop;


### PR DESCRIPTION
…ginal GotoItem functionality

engine.setValue("[Library]","TriggerItem",value)
controllable "gotoitem" trigger with basic context dependent functionality value = -1: using default/original gotoitem implementation value = 0: prefer and check if any valid toggleable item is selected on the sidebar widget and toggle selected item value 1,2,3,4,5: target library focus method, convert value to @FocusWidget enum and set library focus before calling gotoitem